### PR TITLE
bump goa version to 3.9.1 and update formatter type to match goa.httpStatuser

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -16,7 +16,7 @@ type (
 	decoder      = func(*http.Request) goahttp.Decoder
 	encoder      = func(context.Context, http.ResponseWriter) goahttp.Encoder
 	errorHandler = func(context.Context, http.ResponseWriter, error)
-	formatter    = func(error) goahttp.Statuser
+	formatter    = func(context.Context, error) goahttp.Statuser
 	middleware   = func(http.Handler) http.Handler
 
 	// HandlerBuilder represents the goa http handler builder.
@@ -55,9 +55,9 @@ func CheckRedirect(policy func(req *http.Request, via []*http.Request) error) Op
 
 // NoRedirect is the alias of the following:
 //
-//  CheckRedirect(func(req *http.Request, via []*http.Request) error {
-//      return http.ErrUseLastResponse
-//  })
+//	CheckRedirect(func(req *http.Request, via []*http.Request) error {
+//	    return http.ErrUseLastResponse
+//	})
 //
 // Client returns ErrUseLastResponse, the next request is not sent and the most recent
 // response is returned with its body unclosed.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/ikawaha/httpcheck v1.7.0
-	goa.design/goa/v3 v3.9.0
+	goa.design/goa/v3 v3.9.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/ikawaha/httpcheck v1.7.0
-	goa.design/goa/v3 v3.8.5
+	goa.design/goa/v3 v3.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-goa.design/goa/v3 v3.8.5 h1:Y0/6ZwmwZftqQBOlBANU9mP4R+h2gIQUyfQMEs98pGU=
-goa.design/goa/v3 v3.8.5/go.mod h1:+tEl2wNEL54TMAQQ5Mu5il1zl20/7k89XMUv8hVJfa8=
+goa.design/goa/v3 v3.9.0 h1:KFAGJiY7+WPFcHmIgifFgHLm7y0l8auRn/YPL4N5RJw=
+goa.design/goa/v3 v3.9.0/go.mod h1:lgFS8pt76ubyi/K72CxwpAMmxfnS+T08gG8hPTaasNA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 goa.design/goa/v3 v3.9.0 h1:KFAGJiY7+WPFcHmIgifFgHLm7y0l8auRn/YPL4N5RJw=
 goa.design/goa/v3 v3.9.0/go.mod h1:lgFS8pt76ubyi/K72CxwpAMmxfnS+T08gG8hPTaasNA=
+goa.design/goa/v3 v3.9.1 h1:ynzi8fxv5EShdx0rrQ6a7csHs4R+DrFUiBd8HOsWRbM=
+goa.design/goa/v3 v3.9.1/go.mod h1:8rF4yUIx4Pxc9gm+8/m2hkZKnc80wS328CrGWA5ex+I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
goa 3.9.0 introduced a breaking change where error formatters now accept a context as the first argument (https://github.com/goadesign/goa/pull/3137)

This PR updates goa version and updates the formatted type
